### PR TITLE
build: Update workflow to use v5 of create pull request action

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -22,10 +22,16 @@ jobs:
     - name: Update meta data
       run: composer run update-meta-data
 
+    - name: Get current date
+      id: date
+      run: |
+        echo "{date}={$(date +'%Y-%m-%d')}" >> $GITHUB_STATE
+
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       with:
-        commit-message: Nightly update of meta-data.json
+        branch: auto-update-${{ env.date }}
+        commit-message: Auto update of meta-data.json
         title: 'Nightly update of meta-data.json'
         add-paths: |
           meta-data.json


### PR DESCRIPTION
This PR addresses the warning from the actions output:
>[auto-update](https://github.com/DannyvdSluijs/ExactOnlineRestApiReference/actions/runs/7094741929/job/19310528472)
The following actions uses node12 which is deprecated and will be forced to run on node16: peter-evans/create-pull-request@v3. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/